### PR TITLE
An improved sumOfSquares() function.

### DIFF
--- a/code-testing/code/api.js
+++ b/code-testing/code/api.js
@@ -1,10 +1,27 @@
+// Part 1:  sumOfSquares
 
-
-// Part 1:  foo
-function foo(a) {
-  a = a || [];
-  var b = a.map(function(el) { return el * el });
-  return b.reduce(function(s, el) { return s + el }, 0);
+/**
+ * Compute and return the sum of the squares of a iterable sequence of numbers.
+ *
+ * @param {Iterable} numbers - an iterable object whose iterator returns
+ *     a sequence of zero or more numbers.
+ *
+ * @returns {number} the sum of the squares of the specified numbers.
+ *   Returns 0 if the iterator is empty (such as an array of length 0).
+ *   Returns NaN if any element of numbers is not a number or is the NaN
+ *   value itself.
+ *
+ * @throws {TypeError} if numbers is omitted or is not iterable
+ */
+function sumOfSquares(numbers) {
+  let sum = 0;
+  for (let x of numbers) {
+    if (typeof x !== "number") {
+      return NaN;
+    }
+    sum += x * x;
+  }
+  return sum;
 }
 
 
@@ -34,7 +51,7 @@ async function openUrlsInOrder (urlsArray) {
 
 module.exports = {
   openUrlsInOrder,
-  foo
+  sumOfSquares
 }
 
 

--- a/code-testing/code/api.js
+++ b/code-testing/code/api.js
@@ -16,7 +16,7 @@
 function sumOfSquares(numbers) {
   let sum = 0;
   for (let x of numbers) {
-    if (typeof x !== "number") {
+    if (typeof x !== 'number') {
       return NaN;
     }
     sum += x * x;

--- a/code-testing/test/api.js
+++ b/code-testing/test/api.js
@@ -1,21 +1,78 @@
 // assert is like assert, but with some extra functions.
 const assert = require("assert");
 const {
-  foo,
+  sumOfSquares,
   openUrlsInOrder
 } = require('../code/api.js');
 
 
-// part 1: foo
-describe('foo()', function () {
-  it("should do something", function () {
-    assert(false, "foo has no real tests");
-  })
-  it("should do something else", function () {
-    assert(false, "foo has no real tests");
-  })
-});
+// Part 1: sumOfSquares()
+describe('sumOfSquares()', () => {
+  it("is a function", () => {
+    assert.equal(typeof sumOfSquares, 'function');
+  });
 
+  it("returns 0 for the empty array", () => {
+    assert.equal(sumOfSquares([]), 0);
+  });
+
+  it("computes the sum of squares of array values", () => {
+    assert.equal(sumOfSquares([3,4]), 25);
+    assert.equal(sumOfSquares([-3,-4]), 25);
+  });
+
+  it("also works for sets", () => {
+    assert.equal(sumOfSquares(new Set([12,5])), 169);
+    assert.equal(sumOfSquares(new Set()), 0);
+  });
+
+  it("and for generators, too", () => {
+    function* numbers() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+    function* empty() {}
+    assert.equal(sumOfSquares(numbers()), 14);
+    assert.equal(sumOfSquares(empty()), 0);
+  });
+
+  it("returns Infinity if any values are infinite", () => {
+    assert.equal(sumOfSquares([1, Infinity, 2]), Infinity);
+    assert.equal(sumOfSquares([1, -Infinity, 2]), Infinity);
+  });
+
+  it("returns NaN for non-numeric values", () => {
+    assert(Number.isNaN(sumOfSquares([undefined])));
+    assert(Number.isNaN(sumOfSquares([null])));
+    assert(Number.isNaN(sumOfSquares([true])));
+    assert(Number.isNaN(sumOfSquares([false])));
+    assert(Number.isNaN(sumOfSquares(["test"])));
+    assert(Number.isNaN(sumOfSquares(["1"])));
+    assert(Number.isNaN(sumOfSquares("123"))); // iterable string
+    assert(Number.isNaN(sumOfSquares([Symbol("1")])));
+    assert(Number.isNaN(sumOfSquares([{}])));
+    assert(Number.isNaN(sumOfSquares([[]])));
+    assert(Number.isNaN(sumOfSquares([[1]])));
+    assert(Number.isNaN(sumOfSquares([()=>{}])));
+  });
+
+  it("returns NaN if any values are themselves NaN", () => {
+    assert(Number.isNaN(sumOfSquares([NaN])));
+    assert(Number.isNaN(sumOfSquares([0,1,0/0,2])));
+  });
+
+  it("throws TypeError if argument is not iterable", () => {
+    assert.throws(() => sumOfSquares(), TypeError);
+    assert.throws(() => sumOfSquares(null), TypeError);
+    assert.throws(() => sumOfSquares(true), TypeError);
+    assert.throws(() => sumOfSquares(false), TypeError);
+    assert.throws(() => sumOfSquares(0), TypeError);
+    assert.throws(() => sumOfSquares(Symbol('1')), TypeError);
+    assert.throws(() => sumOfSquares({}), TypeError);
+    assert.throws(() => sumOfSquares(()=>{}), TypeError);
+  });
+});
 
 // part 2:  openUrlsInOrder
 describe('openUrlsInOrder()', function () {

--- a/code-testing/test/api.js
+++ b/code-testing/test/api.js
@@ -1,5 +1,5 @@
-// assert is like assert, but with some extra functions.
-const assert = require("assert");
+const { describe, it } = require('mocha');
+const assert = require('assert');
 const {
   sumOfSquares,
   openUrlsInOrder
@@ -8,25 +8,25 @@ const {
 
 // Part 1: sumOfSquares()
 describe('sumOfSquares()', () => {
-  it("is a function", () => {
+  it('is a function', () => {
     assert.equal(typeof sumOfSquares, 'function');
   });
 
-  it("returns 0 for the empty array", () => {
+  it('returns 0 for the empty array', () => {
     assert.equal(sumOfSquares([]), 0);
   });
 
-  it("computes the sum of squares of array values", () => {
+  it('computes the sum of squares of array values', () => {
     assert.equal(sumOfSquares([3,4]), 25);
     assert.equal(sumOfSquares([-3,-4]), 25);
   });
 
-  it("also works for sets", () => {
+  it('also works for sets', () => {
     assert.equal(sumOfSquares(new Set([12,5])), 169);
     assert.equal(sumOfSquares(new Set()), 0);
   });
 
-  it("and for generators, too", () => {
+  it('and for generators, too', () => {
     function* numbers() {
       yield 1;
       yield 2;
@@ -37,32 +37,32 @@ describe('sumOfSquares()', () => {
     assert.equal(sumOfSquares(empty()), 0);
   });
 
-  it("returns Infinity if any values are infinite", () => {
+  it('returns Infinity if any values are infinite', () => {
     assert.equal(sumOfSquares([1, Infinity, 2]), Infinity);
     assert.equal(sumOfSquares([1, -Infinity, 2]), Infinity);
   });
 
-  it("returns NaN for non-numeric values", () => {
+  it('returns NaN for non-numeric values', () => {
     assert(Number.isNaN(sumOfSquares([undefined])));
     assert(Number.isNaN(sumOfSquares([null])));
     assert(Number.isNaN(sumOfSquares([true])));
     assert(Number.isNaN(sumOfSquares([false])));
-    assert(Number.isNaN(sumOfSquares(["test"])));
-    assert(Number.isNaN(sumOfSquares(["1"])));
-    assert(Number.isNaN(sumOfSquares("123"))); // iterable string
-    assert(Number.isNaN(sumOfSquares([Symbol("1")])));
+    assert(Number.isNaN(sumOfSquares(['test'])));
+    assert(Number.isNaN(sumOfSquares(['1'])));
+    assert(Number.isNaN(sumOfSquares('123'))); // iterable string
+    assert(Number.isNaN(sumOfSquares([Symbol('1')])));
     assert(Number.isNaN(sumOfSquares([{}])));
     assert(Number.isNaN(sumOfSquares([[]])));
     assert(Number.isNaN(sumOfSquares([[1]])));
     assert(Number.isNaN(sumOfSquares([()=>{}])));
   });
 
-  it("returns NaN if any values are themselves NaN", () => {
+  it('returns NaN if any values are themselves NaN', () => {
     assert(Number.isNaN(sumOfSquares([NaN])));
     assert(Number.isNaN(sumOfSquares([0,1,0/0,2])));
   });
 
-  it("throws TypeError if argument is not iterable", () => {
+  it('throws TypeError if argument is not iterable', () => {
     assert.throws(() => sumOfSquares(), TypeError);
     assert.throws(() => sumOfSquares(null), TypeError);
     assert.throws(() => sumOfSquares(true), TypeError);


### PR DESCRIPTION
The existing code includes a function named foo() that computes
the sum of the squares of the numbers in an array. This patch
renames that function to sumOfSquares(), adds documentation and
tests for it, and re-implements it to add type checking, to
avoid allocation of an intermediate array, and to make it work
for any iterable argument instead of just arrays.

Note that this re-implementation causes breaking changes to the API:

1) With no argument, `foo()` returned 0, but `sumOfSquares()`
   throws TypeError instead.
2) JavaScript type conversion could cause unexpected return values
   when foo() was invoked with an array of non-numeric values. For
   example `foo([true,true])` returned 2, and `foo([[]])` returned 0.
   When sumOfSquares is invoked with those values, it returns NaN.