### PR TITLE
Fix the openUrlsInOrder() function.

### DIFF
--- a/code-testing/code/api.js
+++ b/code-testing/code/api.js
@@ -18,16 +18,19 @@ async function fakeOpenUrl (url, loadingTime=3*Math.random()) {
   return waitFor(loadingTime).then(()=>console.log(`${url} opened after ${loadingTime}`));
 }
 
-/** opensTabsInOrder
-  *
-  * @returns workDo
-  */
-async function openUrlsInOrder (urlsArray) {
+/**
+ * Simulate opening an array of URLs sequentially, but asynchronously.
+ *
+ * @param {Array<string>} - an array (or iterable) of URLs
+ * @returns {Array<Array<string>>} - a data structure representing the
+ *   simulated loading of the URLs.
+ */
+async function openUrlsInOrder(urlsArray) {
   const work = [];
-  urlsArray.forEach(async (url) => {
+  for(let url of urlsArray) {
     await fakeOpenUrl(url);
     work.push(['url',url]);
-  })
+  }
   work.push(['done',true]);
   return work;
 }
@@ -35,6 +38,6 @@ async function openUrlsInOrder (urlsArray) {
 module.exports = {
   openUrlsInOrder,
   foo
-}
+};
 
 


### PR DESCRIPTION
This patch fixes the openUrlsInOrder() function so that its
tests will pass. The problem is that the previous code was
repeatedly invoking an async function with a forEach() loop
without awaiting the return value of each invocation. This
patch switches to a `for/of` loop which allows us to remove
the extra async function so that we don't need to `await` it.

I wrote this PR to be independent of PR #1, but I fear that by
adding a semicolon at the end of line 41 (to satisfy eslint)
I may have introduced a merge conflict between the two
patches. Apologies if that causes trouble applying them.