### PR TITLE
extension fixes and metric events

### DIFF
--- a/focus-noisy-tab/QA.md
+++ b/focus-noisy-tab/QA.md
@@ -3,7 +3,6 @@
 ## Once
 
 1. Install a Firefox.
-
 2. `npm install -g web-ext`
 
 ## Once per testing session
@@ -15,18 +14,31 @@ web-ext run
 
 ## Tests
 
-### 1.  A noisy tab will steal focus from a non-noisy tab
+### 1. A noisy tab will steal focus from a non-noisy tab
 
 #### setup
-- Open tab:  `youtube.com`
+- Open tab: `youtube.com`
+- In the youtube.com tab, play any video; ensure the tab shows the speaker icon
 - Open new tab.
 
 #### action
-- click Focus Tab Button
+- click "Focus Tab" Button
 
 #### expect
 - the `youtube` tab steals focus.
 
-### 2.  ...
+### 2. A noisy tab in which the source of the noise is paused/muted/stopped will no longer steal focus
 
+#### setup
+- Open tab: `youtube.com`
+- In the youtube.com tab, play any video; ensure the tab shows the speaker icon
+- Open new tab.
+- In the youtube.com tab, pause the video
+- focus on the new tab
 
+#### action
+- Ensure the speaker icon no longer shows for the youtube tab
+- click "Focus Tab" Button
+
+#### expect
+- Focus stays on the new tab.

--- a/focus-noisy-tab/webextension/background.js
+++ b/focus-noisy-tab/webextension/background.js
@@ -3,16 +3,45 @@ function recordData(area, event, fields={}) {
 }
 
 function getNoisyTabs() {
-  return browser.tabs.query({"audible": true});
+  // Note that this is not failsafe: this query is tied to the
+  // value of browser.tabs.delayHidingAudioPlayingIconMS in
+  // about:config, which is set to 3000ms by default.
+  // This value does not just control the hiding of the icon,
+  // it actually controls the audible/muted value for tabs as
+  // well, so it might be worth investigating whether this
+  // is a bug to file, whether we need to inform the user
+  // about this setting, and if we do, whether (and how) to
+  // tell them to update this value for a more responsive
+  // web extension.
+  return browser.tabs.query({
+    "audible": true,
+    "muted": false
+  });
 }
 
 browser.browserAction.onClicked.addListener(async (tab) => {
-  // get some noise tabs.
   recordData('button', 'clicked');
+
+  // get some noise tabs.
   const tabs = await getNoisyTabs();
-  const firstNoisy = tabs[0];
-  // handle 0 noisy tabs
-  if (firstNoisy) {
-    browser.tabs.update(firstNoisy.id,{active: true})
+
+  if (tabs.length === 0) {
+    // If the user invoked this functionality but there are no
+    // noisy tabs, either they're hitting a problem we did not
+    // account for, or our code isn't catching sources of
+    // "noisiness". Either way, we need this data:
+    recordData('query', 'no noisy tabs found');
   }
+
+  // This will let us gather some stats on how many tabs are
+  // noisy when users feel the need to use this feature.
+  // Activations when there's only 1 vs. when there's more than
+  // one lets us gain some insight into possible "why"s of the
+  // user electing to use this feature.
+  recordData('query', `${tabs.length} noisy tabs found`);
+
+  const firstNoisy = tabs[0];
+
+  // shift focus to this tab
+  browser.tabs.update(firstNoisy.id,{active: true})
 });

--- a/focus-noisy-tab/webextension/manifest.json
+++ b/focus-noisy-tab/webextension/manifest.json
@@ -6,8 +6,9 @@
     "scripts": ["background.js"]
   },
   "browser_action": {
+    "browser_style": true,
     "default_icon": {
-      "16": "icons/Audio Mute.svg"
+      "16": "icons/Audio.svg"
     },
     "default_title": "Focus Noisy Tab"
   },


### PR DESCRIPTION
This extension reveals an interesting behaviour in Firefox that might require fixing before we can get meaningful metrics: the speaker icon that shows whether or not a tab is audible is instant when a tab becomes a source of audio, but is on a timed delay when it stops being one, and that delay interferes with an accurate tab query: by default the about:config `browser.tabs.delayHidingAudioPlayingIconMS` setting is pegged to 3000ms so it literally takes three seconds right now for a tab to no longer be an audio source, and the web extension tab query to truthfully tell us that.

If this is a non-essential feature test, I would recommend we file this as potential bug first and see if there's a way to get our API to report the audible/muted state "right now" rather than "once the speaker icon has faded out" so that we're not fighting the API just to get useful metrics here.